### PR TITLE
Console Line Interface

### DIFF
--- a/bin/end-of-life
+++ b/bin/end-of-life
@@ -39,14 +39,14 @@ if (! $loaded) {
     exit(254);
 }
 
-function printPhpEndOfLifeHelp($command)
+function printPhpEndOfLifeHelp($command, $version)
 {
     fwrite(STDERR,
         "PHP End of Life\n"
         . "Expose PHP EOL Date and Check if Version is Supported\n\n"
         . "Usage:\n"
         . ' ' . $command . "\n"
-        . ' ' . $command . " 1.0.0\n"
+        . ' ' . $command . ' ' . $version . "\n"
         . ' ' . $command . " help\n"
     );
 
@@ -63,14 +63,12 @@ function printPhpEndOfLifeError($exception)
 $version = phpversion();
 
 if ($argc > 2) {
-    exit(printPhpEndOfLifeHelp($argv[0]));
+    exit(printPhpEndOfLifeHelp($argv[0], $version));
 }
-
-$version = phpversion();
 
 if ($argc === 2) {
     if ($argv[1] === 'help') {
-        printPhpEndOfLifeHelp($argv[0]);
+        printPhpEndOfLifeHelp($argv[0], $version);
         exit(0);
     }
 

--- a/bin/end-of-life
+++ b/bin/end-of-life
@@ -37,6 +37,13 @@ function printPhpEndOfLifeHelp($command)
     return 2;
 }
 
+function printPhpEndOfLifeError($exception)
+{
+    fwrite(STDERR, $exception->getMessage() . "\n");
+
+    return 2;
+}
+
 $version = phpversion();
 
 if ($argc > 2) {
@@ -53,6 +60,11 @@ if ($argc === 2) {
     $version = $argv[1];
 }
 
-if (! PhpEndOfLife::isSupported($version)) {
-    exit(1);
+try {
+    if (! PhpEndOfLife::isSupported($version)) {
+        // Not Supported!
+        exit(1);
+    }
+} catch (Exception $e) {
+    exit(printPhpEndOfLifeError($e));
 }

--- a/bin/end-of-life
+++ b/bin/end-of-life
@@ -1,0 +1,10 @@
+#!/usr/bin/env php
+<?php
+
+use Cyrosy\PhpEndOfLife\PhpEndOfLife;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+if (! PhpEndOfLife::isSupported(PHP_VERSION)) {
+    exit(1);
+}

--- a/bin/end-of-life
+++ b/bin/end-of-life
@@ -23,6 +23,19 @@ if (! $loaded) {
     exit(254);
 }
 
-if (! PhpEndOfLife::isSupported(PHP_VERSION)) {
+$version = phpversion();
+
+if ($argc > 2) {
+    fwrite(STDERR,
+        "PHP End of Life\n"
+        . "Expose PHP EOL Life Date and Check if Version is Supported\n\n"
+        . "Usage:\n"
+        . ' ' . $argv[0] . "\n"
+        . ' ' . $argv[0] . " 1.0.0\n"
+        . ' ' . $argv[0] . " help\n"
+    );
+}
+
+if (! PhpEndOfLife::isSupported($version)) {
     exit(1);
 }

--- a/bin/end-of-life
+++ b/bin/end-of-life
@@ -1,6 +1,22 @@
 #!/usr/bin/env php
 <?php
 
+/*
+ * PHP End of Life CLI
+ * Expose PHP EOL Date and Check if Version is Supported
+ *
+ * Usage:
+ *   end-of-life
+ *   end-of-life 1.0.0
+ *   end-of-life help
+ *
+ * Return:
+ *     0 Success
+ *     1 Unsupported Version
+ *     2 Invalid Arguments
+ *   254 Unknown Autoload Location
+ */
+
 use Cyrosy\PhpEndOfLife\PhpEndOfLife;
 
 $locations = [
@@ -19,7 +35,7 @@ foreach ($locations as $location) {
 }
 
 if (! $loaded) {
-    fwrite(STDERR, 'Unknown Autoload File Location');
+    fwrite(STDERR, 'Unknown Autoload Location');
     exit(254);
 }
 
@@ -27,7 +43,7 @@ function printPhpEndOfLifeHelp($command)
 {
     fwrite(STDERR,
         "PHP End of Life\n"
-        . "Expose PHP EOL Life Date and Check if Version is Supported\n\n"
+        . "Expose PHP EOL Date and Check if Version is Supported\n\n"
         . "Usage:\n"
         . ' ' . $command . "\n"
         . ' ' . $command . " 1.0.0\n"
@@ -54,7 +70,8 @@ $version = phpversion();
 
 if ($argc === 2) {
     if ($argv[1] === 'help') {
-        exit(printPhpEndOfLifeHelp($argv[0]));
+        printPhpEndOfLifeHelp($argv[0]);
+        exit(0);
     }
 
     $version = $argv[1];
@@ -62,9 +79,11 @@ if ($argc === 2) {
 
 try {
     if (! PhpEndOfLife::isSupported($version)) {
-        // Not Supported!
+        // Unsupported
         exit(1);
     }
+    // Success!
+    exit(0);
 } catch (Exception $e) {
     exit(printPhpEndOfLifeError($e));
 }

--- a/bin/end-of-life
+++ b/bin/end-of-life
@@ -3,7 +3,25 @@
 
 use Cyrosy\PhpEndOfLife\PhpEndOfLife;
 
-require __DIR__ . '/../vendor/autoload.php';
+$locations = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../vendor/autoload.php',
+];
+
+$loaded = false;
+
+foreach ($locations as $location) {
+    if (is_file($location)) {
+        require_once($location);
+        $loaded = true;
+        break;
+    }
+}
+
+if (! $loaded) {
+    fwrite(STDERR, 'Unknown Autoload File Location');
+    exit(254);
+}
 
 if (! PhpEndOfLife::isSupported(PHP_VERSION)) {
     exit(1);

--- a/bin/end-of-life
+++ b/bin/end-of-life
@@ -23,17 +23,34 @@ if (! $loaded) {
     exit(254);
 }
 
-$version = phpversion();
-
-if ($argc > 2) {
+function printPhpEndOfLifeHelp($command)
+{
     fwrite(STDERR,
         "PHP End of Life\n"
         . "Expose PHP EOL Life Date and Check if Version is Supported\n\n"
         . "Usage:\n"
-        . ' ' . $argv[0] . "\n"
-        . ' ' . $argv[0] . " 1.0.0\n"
-        . ' ' . $argv[0] . " help\n"
+        . ' ' . $command . "\n"
+        . ' ' . $command . " 1.0.0\n"
+        . ' ' . $command . " help\n"
     );
+
+    return 2;
+}
+
+$version = phpversion();
+
+if ($argc > 2) {
+    exit(printPhpEndOfLifeHelp($argv[0]));
+}
+
+$version = phpversion();
+
+if ($argc === 2) {
+    if ($argv[1] === 'help') {
+        exit(printPhpEndOfLifeHelp($argv[0]));
+    }
+
+    $version = $argv[1];
 }
 
 if (! PhpEndOfLife::isSupported($version)) {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
   "require-dev": {
     "phpunit/phpunit": "*"
   },
+  "bin": [
+    "bin/end-of-life"
+  ],
   "config": {
     "sort-packages": true
   }


### PR DESCRIPTION
This PR adds a CLI to check if current (or passed) version is supported by PHP.

Usage:

```
./bin/end-of-life
./bin/end-of-life 7.3
./bin/end-of-life help
```

It will return `0` if success, `1` if unsupported, `2` if invalid arguments or `254` if autoload was not found.